### PR TITLE
pyspark excluded from requirements

### DIFF
--- a/examples/simple_example.ipynb
+++ b/examples/simple_example.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "import sys\n",
     "\n",
-    "sys.path.append(\"../pure/\")"
+    "sys.path.append(\"../\")"
    ]
   },
   {
@@ -29,7 +29,7 @@
     "import pandas as pd\n",
     "import numpy as np\n",
     "\n",
-    "from report import Report"
+    "from pure.report import Report"
    ]
   },
   {
@@ -605,7 +605,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from metrics import (\n",
+    "from pure.metrics import (\n",
     "    CountTotal,\n",
     "    CountZeros,\n",
     "    CountNull,\n",
@@ -995,7 +995,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from metrics import CountCB, CountLag, CountLastDayRows"
+    "from pure.metrics import CountCB, CountLag, CountLastDayRows"
    ]
   },
   {
@@ -1050,7 +1050,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'today': '2023-07-26', 'last_day': '2018-12-13', 'lag': 1686}\n"
+      "{'today': '2023-08-10', 'last_day': '2018-12-13', 'lag': 1701}\n"
      ]
     }
    ],
@@ -1094,7 +1094,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/pure/report.py
+++ b/pure/report.py
@@ -1,17 +1,20 @@
 """Valid report."""
 
+from __future__ import annotations
 from dataclasses import dataclass
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Tuple, Union, TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
-import pyspark.sql as ps
 
-from metrics import Metric
-from sql_connector import ClickHouseConnector, PostgreSQLConnector, MSSQLConnector
+from pure.metrics import Metric
+from pure.sql_connector import ClickHouseConnector, PostgreSQLConnector, MSSQLConnector
 
 LimitType = Dict[str, Tuple[float, float]]
 CheckType = Tuple[str, Metric, LimitType]
+
+if TYPE_CHECKING:
+    import pyspark.sql as ps
 
 
 @dataclass

--- a/pure/tests/test_fixtures/metric_cases.py
+++ b/pure/tests/test_fixtures/metric_cases.py
@@ -1,7 +1,7 @@
 """Test cases."""
 import datetime as dt
 
-from test_fixtures.tables import TABLES1, TABLES2
+from pure.tests.test_fixtures.tables import TABLES1, TABLES2
 
 today = dt.datetime.now()
 # Each metric can have multiple test cases with different tables,

--- a/pure/tests/test_fixtures/report_cases.py
+++ b/pure/tests/test_fixtures/report_cases.py
@@ -1,6 +1,6 @@
 """Test cases."""
-from test_fixtures.report_checklists import CHECKLIST1, CHECKLIST2
-from test_fixtures.tables import TABLES1, TABLES2
+from pure.tests.test_fixtures.report_checklists import CHECKLIST1, CHECKLIST2
+from pure.tests.test_fixtures.tables import TABLES1, TABLES2
 
 TEST_CASES = [
     {

--- a/pure/tests/test_fixtures/report_checklists.py
+++ b/pure/tests/test_fixtures/report_checklists.py
@@ -1,7 +1,7 @@
 """Test cases."""
 import datetime as dt
 
-import metrics as m
+import pure.metrics as m
 
 # Checklist contains checks consist of:
 # - table_name

--- a/pure/tests/test_report.py
+++ b/pure/tests/test_report.py
@@ -2,9 +2,9 @@ import os
 import pickle
 
 import pandas as pd
-from test_fixtures.report_cases import TEST_CASES as report_cases
+from pure.tests.test_fixtures.report_cases import TEST_CASES as report_cases
 
-from report import Report
+from pure.report import Report
 
 
 def test_report_pandas():

--- a/pure/utils.py
+++ b/pure/utils.py
@@ -1,0 +1,36 @@
+import importlib
+
+
+class PySparkSingleton:
+    '''
+    Singleton implementation for importing and using the PySpark modules: `sql`, `functions`.
+
+    Only one instance of the class is created, properties provides access to corresponding modules.
+    '''
+    _instance = None
+    _version = "3.4.0"
+
+    def __new__(cls):
+        if cls._instance is None:
+            try:
+                cls._instance = super().__new__(cls)
+                cls._instance.sql_ = importlib.import_module('pyspark.sql')
+                cls._instance.functions = importlib.import_module('pyspark.sql.functions')
+            except ImportError:
+                print('Failed to import PySpark module.')
+                print(f'Check if pyspark is installed, recommended version: {cls._version}')
+                raise
+
+        return cls._instance
+
+    @property
+    def sql(self):
+        '''pyspark.sql module'''
+
+        return self._instance.sql_
+
+    @property
+    def func(self):
+        '''pyspark.sql.functions module'''
+
+        return self._instance.functions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 numpy==1.24.3
 pandas==2.0.0
 pylint==2.17.2
-pyspark==3.4.0
 pytest==7.3.1
 scikit-learn==1.2.2
 clickhouse_driver==0.2.6


### PR DESCRIPTION
PySpark Singleton class for import/use pyspark modules
fixed imports as `pure.<module><submodule>`